### PR TITLE
fix(Box): correct width assignment and extend background support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepare": "husky install"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",
     "react-router-dom": "^6.22.3",
@@ -51,7 +51,7 @@
     "@storybook/blocks": "^8.0.2",
     "@storybook/react-vite": "^8.0.2",
     "@storybook/test": "^8.0.2",
-    "@types/react": "^18.2.43",
+    "@types/react": "^18.3.23",
     "@types/react-dom": "^18.2.17",
     "@types/styled-components": "^5.1.34",
     "@typescript-eslint/eslint-plugin": "^6.14.0",

--- a/src/components/Box/Box.stories.tsx
+++ b/src/components/Box/Box.stories.tsx
@@ -16,6 +16,7 @@ Default.args = {
   margin: "0px",
   padding: "16px",
   borderRadius: "8px",
+  appearance: "light",
 };
 
 const Composition = (args: IBox) => (

--- a/src/components/Box/README.md
+++ b/src/components/Box/README.md
@@ -22,6 +22,13 @@ import { Box } from "@inubekit/inubekit";
 
 ## Props
 
+### appearance (opcional)
+
+Color que se mostrara en el background del componente.
+
+1. Opciones:`"dark"`, `"gray"`, `"light"`
+2. **Por defecto: `"light"`**
+
 ### margin (opcional)
 
 Controla el margen alrededor del componente. Considera lo siguiente:

--- a/src/components/Box/TOKENS.md
+++ b/src/components/Box/TOKENS.md
@@ -4,6 +4,11 @@
 
 **reference**: used when the tokes points to another token.
 
-| token                  | value | reference                 |
-| ---------------------- | ----- | ------------------------- |
-| inube.box.border.color |       | inube.palette.neutral.n40 |
+| token                            | value | reference |
+| -------------------------------- | ----- | --------- |
+| inube.box.gray.border.color      |       |           |
+| inube.box.gray.background.color  |       |           |
+| inube.box.light.border.color     |       |           |
+| inube.box.light.background.color |       |           |
+| inube.box.dark.border.color      |       |           |
+| inube.box.dark.background.color  |       |           |

--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -1,6 +1,7 @@
 import { StyledBox } from "./styles";
 
 interface IBox {
+  appearance?: string;
   children?: React.ReactNode;
   padding?: string;
   margin?: string;
@@ -11,6 +12,7 @@ interface IBox {
 
 function Box(props: IBox) {
   const {
+    appearance = "light",
     children,
     padding = "16px",
     margin,
@@ -20,6 +22,7 @@ function Box(props: IBox) {
   } = props;
   return (
     <StyledBox
+      $appearance={appearance}
       $padding={padding}
       $margin={margin}
       $borderRadius={borderRadius}

--- a/src/components/Box/styles.js
+++ b/src/components/Box/styles.js
@@ -6,11 +6,15 @@ import { box } from "./tokens";
 const StyledBox = styled.div`
   border-width: 1px;
   border-style: solid;
-  border-color: ${({ theme }) => theme?.box?.border?.color || box.border.color};
+  border-color: ${({ theme, $appearance }) =>
+    theme?.box?.[$appearance]?.border?.color || box[$appearance].border.color};
+  background: ${({ theme, $appearance }) =>
+    theme?.box?.[$appearance]?.background?.color ||
+    box[$appearance].background.color};
   border-radius: ${({ $borderRadius }) => $borderRadius};
   margin: ${({ $margin }) => $margin};
   padding: ${({ $padding }) => $padding};
-  width: ${($width) => $width};
+  width: ${({ $width }) => $width};
   height: ${({ $height }) => $height};
   box-sizing: border-box;
 `;

--- a/src/components/Box/tokens.ts
+++ b/src/components/Box/tokens.ts
@@ -1,8 +1,29 @@
 import { palette } from "../Foundations/palette";
 
 const box = {
-  border: {
-    color: palette.neutral.N40,
+  dark: {
+    border: {
+      color: palette.neutral.N40,
+    },
+    background: {
+      color: palette.neutral.N900,
+    },
+  },
+  gray: {
+    border: {
+      color: palette.neutral.N40,
+    },
+    background: {
+      color: palette.neutral.N20,
+    },
+  },
+  light: {
+    border: {
+      color: palette.neutral.N40,
+    },
+    background: {
+      color: palette.neutral.N0,
+    },
   },
 };
 


### PR DESCRIPTION
This PR resolves an issue in the Box component where the width property was mistakenly assigned the padding value due to a typo, causing it to be ignored and fallback to auto, which led to layout inconsistencies. Additionally, this update introduces a new prop to control the background appearance, extending the component’s functionality in line with the latest design mockups requirements. 