### PR TITLE
fix(Autocomplete): select, search, and clean when blurring have been fixed.

### DIFF
--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -17,6 +17,7 @@ interface IIcon {
   shape?: IIconShape;
   size?: string;
   onClick?: (e: React.MouseEvent) => void;
+  cursor?: string;
 }
 
 const Icon = (props: IIcon) => {
@@ -31,6 +32,7 @@ const Icon = (props: IIcon) => {
     shape,
     size = "24px",
     onClick,
+    cursor,
   } = props;
 
   const interceptOnClick = (e: React.MouseEvent) => {
@@ -51,6 +53,7 @@ const Icon = (props: IIcon) => {
       $variant={variant}
       $shape={shape}
       $size={size}
+      $cursor={cursor}
       onClick={disabled ? undefined : interceptOnClick}
     >
       {icon}

--- a/src/components/Icon/props.ts
+++ b/src/components/Icon/props.ts
@@ -106,6 +106,11 @@ const props = {
     control: { type: "text" },
     description: "size of the icon in pixels",
   },
+
+  cursor: {
+    control: { type: "text" },
+    description: "cursor style when hovering over the icon",
+  },
 };
 
 export { parameters, props, shapes, spacings, variants };

--- a/src/components/Icon/styles.js
+++ b/src/components/Icon/styles.js
@@ -17,6 +17,7 @@ const StyledIcon = styled.figure`
       if ($spacing === "compact") return "4px";
       return "0px";
     }};
+    cursor: ${({ $cursor }) => $cursor};
 
     color: ${({ theme, $variant, $appearance, $parentHover, disabled }) => {
       if (disabled)

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -77,6 +77,7 @@ const Select = (props: ISelect) => {
   function handleClear() {
     onChange(name, "");
     setCheckedItems([]);
+    setDisplayList(false);
   }
 
   function handleClick(event: React.ChangeEvent<HTMLInputElement>) {

--- a/src/components/Select/interface.tsx
+++ b/src/components/Select/interface.tsx
@@ -163,7 +163,7 @@ const SelectUI = forwardRef((props: ISelectInterface, ref) => {
         $disabled={disabled}
         $focused={focused}
         $invalid={invalid}
-        onClick={onClick}
+        onClick={!editable ? onClick : undefined}
         $value={value}
         $size={size}
       >
@@ -184,7 +184,7 @@ const SelectUI = forwardRef((props: ISelectInterface, ref) => {
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             onChange(name, e.target.value)
           }
-          onClick={onClick}
+          onClick={editable ? onClick : undefined}
           onKeyUp={onKeyUp}
         />
         <Stack direction="row" gap="8px" alignItems="center">
@@ -196,6 +196,7 @@ const SelectUI = forwardRef((props: ISelectInterface, ref) => {
                 icon={<MdOutlineCancel />}
                 size="16px"
                 onClick={handleClear}
+                cursor="pointer"
               />
             )}
 

--- a/src/components/Select/styles.js
+++ b/src/components/Select/styles.js
@@ -25,10 +25,10 @@ const StyledInputContainer = styled.div`
   align-items: center;
   box-sizing: border-box;
   border-radius: 8px;
-  user-select: none;
   pointer-events: ${({ $disabled }) => $disabled && "none"};
   grid-auto-flow: column;
   grid-template-columns: 1fr auto;
+  cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
   background-color: ${({ $disabled, theme }) =>
     $disabled
       ? theme?.input?.background?.color?.disabled ||
@@ -54,6 +54,8 @@ const StyledInput = styled.input`
   border: none;
   width: 100%;
   background-color: transparent;
+  cursor: ${({ readOnly, $disabled }) =>
+    $disabled ? "not-allowed" : readOnly ? "pointer" : "text"};
   font-family: ${({ theme }) =>
     theme?.typography?.body?.large?.font || inube.typography.body.large.font};
   font-size: ${({ theme }) =>


### PR DESCRIPTION
Se tomaron en cuenta los siguientes errores y comportamientos no deseados y se solucionaron:

1. Digito la letra 'd'.
2. Con sólo esa letra deja de sugerir opciones.
3. Agrego la letra 'o', para que quede 'do'
4. Ahora me muestra toda la lista de divisas, sin filtros.
5. Agrego la letra 'l' -> no sugiere nada
6. Agrego la letra 'a' -> muestra la lista entera otra vez.

Se comprobo que el componente ahora funciona de la siguiente manera:

1. Voy digitando e internamente debería haber un filter que evalúe que la option incluya el string digitado.
2. Toda option que sí contenga como substring lo que el usuario digita, debería mostrarse como opción.
3. Para el caso del Autocomplete, si digito 'dolaritos' y me salgo del componente, ese valor se queda ahí registrado. Aquí el campo debería resetearse y quedar en blanco porque lo que digité no es una opción válida.
6. En el Autocomplete el usuario debe escoger una opción. No importa lo que escriba, debe escoger. Si no escoge, es como si no hubiera puesto nada y el campo se reinicia en caso de abandonarlo (blur).